### PR TITLE
Implement add-todo and tests

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { UserProfileComponent } from './users/user-profile.component';
 import { AddUserComponent } from './users/add-user.component';
 import { TodoListComponent } from './todos/todo-list/todo-list.component';
 import { TodoProfileComponent } from './todos/todo-profile/todo-profile.component';
+import { AddTodoComponent } from './todos/add-todo/add-todo.component';
 
 
 const routes: Routes = [
@@ -14,7 +15,8 @@ const routes: Routes = [
   {path: 'users/new', component: AddUserComponent},
   {path: 'users/:id', component: UserProfileComponent},
   {path: 'todos', component: TodoListComponent},
-  {path: 'todos/:id', component: TodoProfileComponent}
+  {path: 'todos/:id', component: TodoProfileComponent},
+  {path: 'todos/new', component: AddTodoComponent}
 
 ];
 

--- a/client/src/app/todos/add-todo/add-todo.component.spec.ts
+++ b/client/src/app/todos/add-todo/add-todo.component.spec.ts
@@ -1,25 +1,160 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormGroup, AbstractControl } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockTodoService } from 'src/testing/todo.service.mock';
 import { AddTodoComponent } from './add-todo.component';
+import { TodoService } from '../todo.service';
 
 describe('AddTodoComponent', () => {
-  let component: AddTodoComponent;
+  let addTodo: AddTodoComponent;
+  let addTodoForm: FormGroup;
   let fixture: ComponentFixture<AddTodoComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ AddTodoComponent ]
-    })
-    .compileComponents();
-  });
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        MatSnackBarModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatSelectModule,
+        MatInputModule,
+        BrowserAnimationsModule,
+        RouterTestingModule
+      ],
+      declarations: [AddTodoComponent],
+      providers: [{ provide: TodoService, useValue: new MockTodoService() }]
+    }).compileComponents().catch(error => {
+      expect(error).toBeNull();
+    });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AddTodoComponent);
-    component = fixture.componentInstance;
+    addTodo = fixture.componentInstance;
+    addTodo.ngOnInit();
     fixture.detectChanges();
+    addTodoForm = addTodo.addTodoForm;
+    expect(addTodoForm).toBeDefined();
+    expect(addTodoForm.controls).toBeDefined();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(addTodo).toBeTruthy();
+  });
+
+  it('should create the component and the form', () => {
+    expect(addTodo).toBeTruthy();
+    expect(addTodoForm).toBeTruthy();
+  });
+
+  it('the form should be invalid when empty', () => {
+    expect(addTodoForm.valid).toBeFalsy();
+  });
+
+  describe('Owner field', () => {
+    let ownerControl: AbstractControl;
+
+    beforeEach(() => {
+      ownerControl = addTodo.addTodoForm.controls.owner;
+    });
+
+    it('should not allow an empty owner', () => {
+      ownerControl.setValue('');
+      expect(ownerControl.valid).toBeFalsy();
+    });
+
+    it('should be fine with 1 character', () => {
+      ownerControl.setValue('a');
+      expect(ownerControl.valid).toBeTruthy();
+    });
+
+    it('should be fine with "Richard"', () => {
+      ownerControl.setValue('Richard');
+      expect(ownerControl.valid).toBeTruthy();
+    });
+
+    it('should fail on more than 50 characters', () => {
+      ownerControl.setValue('x'.repeat(51));
+      expect(ownerControl.valid).toBeFalsy();
+    });
+
+    it('should allow 50 characters', () => {
+      ownerControl.setValue('x'.repeat(50));
+      expect(ownerControl.valid).toBeTruthy();
+    });
+  });
+
+  describe('The category field', () => {
+    let catControl: AbstractControl;
+
+    beforeEach(() => {
+      catControl = addTodo.addTodoForm.controls.category;
+    });
+
+    it('should not allow an empty category', () => {
+      catControl.setValue('');
+      expect(catControl.valid).toBeFalsy();
+    });
+
+    it('should be fine with 1 character', () => {
+      catControl.setValue('j');
+      expect(catControl.valid).toBeTruthy();
+    });
+
+    it('should be fine with "shopping"', () => {
+      catControl.setValue('shopping');
+      expect(catControl.valid).toBeTruthy();
+    });
+
+    it('should fail on more than 50 characters', () => {
+      catControl.setValue('x'.repeat(51));
+      expect(catControl.valid).toBeFalsy();
+    });
+
+    it('should allow 50 characters', () => {
+      catControl.setValue('x'.repeat(50));
+      expect(catControl.valid).toBeTruthy();
+    });
+  });
+
+  describe('The body field', () => {
+    let bodyControl: AbstractControl;
+
+    beforeEach(() => {
+      bodyControl = addTodo.addTodoForm.controls.body;
+    });
+
+    it('should not allow an empty body', () => {
+      bodyControl.setValue('');
+      expect(bodyControl.valid).toBeFalsy();
+    });
+
+    it('should be fine with 1 character', () => {
+      bodyControl.setValue('h');
+      expect(bodyControl.valid).toBeTruthy();
+    });
+
+    it('should be fine with "buy new shoes"', () => {
+      bodyControl.setValue('buy new shoes');
+      expect(bodyControl.valid).toBeTruthy();
+    });
+
+    it('should fail on more than 150 characters', () => {
+      bodyControl.setValue('x'.repeat(151));
+      expect(bodyControl.valid).toBeFalsy();
+    });
+
+    it('should allow 150 characters', () => {
+      bodyControl.setValue('x'.repeat(150));
+      expect(bodyControl.valid).toBeTruthy();
+    });
   });
 });

--- a/client/src/app/todos/add-todo/add-todo.component.ts
+++ b/client/src/app/todos/add-todo/add-todo.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { Todo } from '../todo';
+import { TodoService } from '../todo.service';
 
 @Component({
   selector: 'app-add-todo',
@@ -7,9 +12,79 @@ import { Component, OnInit } from '@angular/core';
 })
 export class AddTodoComponent implements OnInit {
 
-  constructor() { }
+  addTodoForm: FormGroup;
+
+  todo: Todo;
+
+  addTodoValidationMessages = {
+    owner: [
+      {type: 'required', message: 'An owner is required'},
+      {type: 'minlength', message: 'Owner must be at least 1 character long'},
+      {type: 'maxlength', message: 'Owner cannot be more than 50 characters long'},
+    ],
+
+    category: [
+      {type: 'required', message: 'A category is required'},
+      {type: 'minlength', message: 'Category must be at least 1 character long'},
+      {type: 'maxlength', message: 'Category cannot be more than 50 characters long'}
+    ],
+
+    body: [
+      {type: 'required', message: 'A body is required'},
+      {type: 'minlength', message: 'Body must be at least 1 character long'},
+      {type: 'maxlength', message: 'Body cannot be more than 150 characters long'}
+    ]
+
+    // We chose to not ask for the status of the todo since it would be weird to add a completed todo
+  };
+
+  constructor(private fb: FormBuilder, private todoService: TodoService, private snackBar: MatSnackBar, private router: Router) { }
+
+  createForms() {
+
+    this.addTodoForm = this.fb.group({
+      owner: new FormControl('', Validators.compose([
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(50),
+        (fc) => {
+          if(fc.value.toLowerCase() === 'abc123' || fc.value.toLowerCase() === '123abc') {
+            return ({existingOwner: true});
+          } else {
+            return null;
+          }
+        },
+      ])),
+
+      category: new FormControl('', Validators.compose([
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(50)
+      ])),
+
+      body: new FormControl('', Validators.compose([
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(150)
+      ])),
+    });
+  }
 
   ngOnInit(): void {
+    this.createForms();
+  }
+
+  submitForm() {
+    this.todoService.addTodo(this.addTodoForm.value).subscribe(newID => {
+      this.snackBar.open('Added Todo ' + this.addTodoForm.value.owner, null, {
+        duration: 2000,
+      });
+      this.router.navigate(['/todos/', newID]);
+    }, err => {
+      this.snackBar.open('Failed to add the todo', 'OK', {
+        duration: 5000,
+      });
+    });
   }
 
 }

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -170,5 +170,18 @@ describe('TodoService', () => {
         todo.body.indexOf(todoBody)).toBeGreaterThanOrEqual(0);
       });
     });
+
+    it('addTodo() posts the todo to api/todos', () => {
+      service.addTodo(testTodos[2]).subscribe(
+        id => expect(id).toBe('testID')
+      );
+
+      const req = httpTestingController.expectOne(service.todoUrl);
+
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual(testTodos[2]);
+
+      req.flush({ id: 'testID' });
+    });
   });
 });

--- a/client/src/app/todos/todo.service.ts
+++ b/client/src/app/todos/todo.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { Todo } from './todo';
+import { map } from 'rxjs/operators';
 
 
 @Injectable({
@@ -49,5 +50,9 @@ export class TodoService {
       filteredTodos = filteredTodos.slice(0,filters.limit);
     }
     return filteredTodos;
+  }
+
+  addTodo(newTodo: Todo): Observable<string> {
+    return this.httpClient.post<{id: string}>(this.todoUrl, newTodo).pipe(map(res => res.id));
   }
 }


### PR DESCRIPTION
Implemented the add-todo TypeScript and tested each of its methods.

Added the addTodo() method into todo.service and created a test in todo.service.spec accordingly.

Added a new route in app-routing for creating a new todo, although it currently leads to an empty page.